### PR TITLE
CSS Update for Alternate Screen Size Ratios

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,10 +45,8 @@
 			</linearGradient> 
 			<rect id="sky" x="0" y="0" width="100%" height="100%"  style="fill:url(#skyGradient)" /> 
 		</svg>
-		<div id="sunMoonCycle">
-			<div class="sun"></div>
-			<div class="moon"></div>
-		</div>
+		<div class="sun"></div>
+		<div class="moon"></div>
 	</div>
 
 	<div id="clock">

--- a/scripts.js
+++ b/scripts.js
@@ -18,8 +18,10 @@ window.addEventListener('load', () => {
 		
 		document.getElementById("skyGradient").innerHTML += ""; //reload the svgs
 		
-		document.getElementById('sunMoonCycle').style.animationDuration = "86400s";
-		document.getElementById('sunMoonCycle').style.animationDelay = '-' + (totalSeconds + 43200) + 's';
+		document.getElementsByClassName('sun')[0].style.animationDuration = "86400s";
+		document.getElementsByClassName('moon')[0].style.animationDuration = "86400s";
+		document.getElementsByClassName('sun')[0].style.animationDelay = '-' + totalSeconds + 's';
+		document.getElementsByClassName('moon')[0].style.animationDelay = '-' + totalSeconds + 's';
 	};
 	for(var i = 0; i < 25; i++) {
 		var cloudSpeed = Math.floor(Math.random() * 30) + 1;

--- a/styles.css
+++ b/styles.css
@@ -5,6 +5,10 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300&display=swap');
 
+:root {
+	--front-height: calc(472.75px - (0.195 * 100vw));
+}
+
 #about {
     font-family: 'Open Sans', sans-serif;
 	position: absolute;
@@ -127,7 +131,7 @@ canvas {
 	width: 100vw;
 	z-index: 5;
 	bottom: 0;
-	height: calc(472.75px - (0.195 * 100vw));
+	height: var(--front-height);
 }
 
 #topLayer {

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,14 @@
-@keyframes rotateSunAndMoon {	
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+@keyframes rotateMoon {	
+	from { transform: rotate(-180deg) translateY(42.5vw) rotate(180deg); }
+	to { transform: rotate(180deg) translateY(42.5vw) rotate(-180deg); }
 }
+
+@keyframes rotateSun {	
+	from { transform: rotate(-180deg) translateY(-42.5vw) rotate(180deg); }
+	to { transform: rotate(180deg) translateY(-42.5vw) rotate(-180deg); }
+}
+
+
 
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300&display=swap');
 
@@ -31,23 +38,11 @@
 	z-index: 1;
 }
 
-#sunMoonCycle {
-	/* width: 100vw; */
-	height: 100vw;
-	position: relative;
-	/* max-width: 100%; */
-	/* max-height: 100vh; */
-	margin: auto;
-	display: flex;
-	align-items: center;
-    justify-content: space-between;
-	flex-wrap: wrap;
-	flex-direction: column;
-	animation: rotateSunAndMoon 48s infinite linear;
-	animation-delay: -24s;
-}
-
 .sun {
+  position: absolute;
+	bottom: calc(var(--front-height) - 7.5vw);
+  left: 42.5vw;
+  animation: rotateSun 48s infinite linear;
   width: 15vw;
   height: 15vw;
   background-image: url("media/Jermasun.png");
@@ -55,11 +50,14 @@
 }
 
 .moon {
+	position: absolute;
+	bottom: calc(var(--front-height) - 7.5vw);
+	left: 42.5vw;
+	animation: rotateMoon 48s infinite linear;
   width: 15vw;
   height: 15vw;
   background-image: url("media/Jermamoon.png");
   background-size: cover;
-  transform: scaleY(-1);
 }
 
 * {

--- a/styles.css
+++ b/styles.css
@@ -148,7 +148,7 @@ canvas {
 }
 
 #clock {
-	--clock-font-size: 10rem;
+	--clock-font-size: 8vw;
 	position: absolute;
 	top: calc(50% - var(--clock-font-size) / 2);
 	left: 0;


### PR DESCRIPTION
Reason for change:
On screen sizes that are not a 16:9 ratio, the resizing of clock text and animations of the planets revolving begin acting strangely. These changes are meant to soothe some of the issues caused by resizing.

List of changes:
-- (--front-height) variable added for access to the height of the front dirt layer in the viewport.
-- CSS animations have been created and modified for the sun and moon images
-- The div containing the sun and moon have been removed as it is no longer necessary to rotate this box for the animation.
-- The clock text has been modified to react to the viewport instead of reacting to the user's defined text size.

Again, I have tried to keep the code as readable as possible for this revamp and minimal modifications have been made to the existing formatting.